### PR TITLE
Fixed 'offset' without 'limit' error

### DIFF
--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -106,12 +106,17 @@ class Laratables
         $orderByValue = $this->columnManager->getOrderBy();
         $orderByStatement = is_array($orderByValue) ? 'orderBy' : 'orderByRaw';
         $orderByValue = Arr::wrap($orderByValue);
+        $length = (int)request('length');
 
-        return $query->with($this->columnManager->getRelations())
-            ->offset((int) request('start'))
-            ->limit(min((int) request('length'), 100))
-            ->{$orderByStatement}(...$orderByValue)
-            ->get($this->columnManager->getSelectColumns());
+        return $length > -1
+            ? $query->with($this->columnManager->getRelations())
+                ->offset((int)request('start'))
+                ->limit($length)
+                ->{$orderByStatement}(...$orderByValue)
+                ->get($this->columnManager->getSelectColumns())
+            : $query->with($this->columnManager->getRelations())
+                ->{$orderByStatement}(...$orderByValue)
+                ->get($this->columnManager->getSelectColumns());
     }
 
     /**


### PR DESCRIPTION
When datatable sends a length of -1, the offset is included in the query without a limit; this throws an error. To solve this, if the length is less than 0, we can do without the 'limit' and 'offset'.